### PR TITLE
added in the egg and the dist dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __pycache__ 
 .pytest_cache
 *.pyc
+mnmetro.egg-info/
+dist/
 
 # Coverage
 .coverage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add in the directories that are made when pushing a package up to pypi. I don't know if it's common practice to leave them in or not so I'm just not for now

## Related Issue
None

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Not 100% sure
<!--- If it fixes an open issue, please link to the issue here. -->
Nope

## How Has This Been Tested?
No testing needed

## Screenshots (if appropriate):
